### PR TITLE
feat: add EN/ES internationalization with auto geo-redirect

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,118 @@
+{
+  "nav": {
+    "contact": "Contact",
+    "github": "GitHub"
+  },
+  "hero": {
+    "role": "Product Engineer",
+    "bio": "10+ years of experience building scalable web applications. Specialized in Frontend development with React and TypeScript since 2017, delivering MVPs and full platforms for startups and tech-driven teams.",
+    "location": "Buenos Aires, Argentina",
+    "getInTouch": "Get In Touch",
+    "downloadResume": "Download Resume"
+  },
+  "skills": {
+    "sectionTitle": "Core Skills",
+    "professionalTitle": "Professional Skills",
+    "languagesTitle": "Languages",
+    "spanish": "Spanish",
+    "spanishLevel": "Native",
+    "english": "English",
+    "englishLevel": "B2/C1 Professional",
+    "items": [
+      "Full-Stack Web Development",
+      "Rapid Prototyping & MVP Delivery",
+      "Product Thinking & User-Centered Design",
+      "Codebase Scalability & Maintainability",
+      "Cross-functional Collaboration",
+      "Agile Methodologies"
+    ]
+  },
+  "techStack": {
+    "sectionTitle": "Tech Stack",
+    "cardTitle": "Technologies & Tools",
+    "cardDescription": "Modern technologies I use to build scalable applications"
+  },
+  "experience": {
+    "sectionTitle": "Work Experience",
+    "jobs": [
+      {
+        "title": "Founding Engineer",
+        "company": "Bondly",
+        "period": "09/24 - Present",
+        "description": "Owned full lifecycle. Launched cookie consent, rebuilt scheduling tool, improved SEO and tracking.",
+        "stack": "Next.js, Remix, NestJS, Supabase, TypeScript, AI tools"
+      },
+      {
+        "title": "Freelance Developer",
+        "company": "Independent",
+        "period": "2023 - Present",
+        "description": "Building high-performance web applications and MVPs. Collaborated with CTOs and CEOs on startup initiatives.",
+        "stack": "Next.js, React, TypeScript, Tailwind CSS, AWS Serverless"
+      },
+      {
+        "title": "Senior Full Stack Engineer",
+        "company": "StackZone",
+        "period": "03/22 - 08/23",
+        "description": "Improved WebApp via refactoring, mentoring, and TS best practices. Built cost modules and Serverless APIs.",
+        "stack": "React, TypeScript, AWS, Redux-Saga, Cypress, PostgreSQL"
+      },
+      {
+        "title": "Lead Frontend Developer",
+        "company": "Commit Studio",
+        "period": "11/21 - 03/22",
+        "description": "Led feature development and team support. Delivered credit partner platform (PedidosYa) and e-commerce CLI.",
+        "stack": "Next.js, TypeScript, MySQL, Redux-Toolkit"
+      },
+      {
+        "title": "Sr Software Engineer",
+        "company": "Santander Tecnologia",
+        "period": "06/20 - 11/21",
+        "description": "Frontend lead for Checks team. Built microsites and BFF with NestJS. Led internal React training.",
+        "stack": "React, NestJS, TypeScript, Redux-Toolkit"
+      },
+      {
+        "title": "Software Engineer",
+        "company": "ParkAssist",
+        "period": "06/20 - 11/21",
+        "description": "Developed parking admin platform using AWS and React. Delivered performant client-side features.",
+        "stack": "React, TypeScript, Redux, AWS IAM, IoT, DynamoDB"
+      }
+    ]
+  },
+  "education": {
+    "sectionTitle": "Education & Certifications",
+    "educationTitle": "Education",
+    "degreeTitle": "Superior Software Development Technician",
+    "degreeSchool": "ISTEA - Tertiary Degree",
+    "degreePeriod": "2014 - 2017",
+    "certificationsTitle": "Certifications",
+    "cert1Title": "Epic React",
+    "cert1Provider": "Kent C. Dodds (epicreact.dev)",
+    "cert2Title": "CSS-in-JS",
+    "cert2Provider": "Josh W. Comeau (css-for-js.dev)"
+  },
+  "contact": {
+    "sectionTitle": "Let's Work Together",
+    "body": "Ready to build something amazing? I'm always open to discussing new opportunities and interesting projects.",
+    "githubLabel": "GitHub Profile"
+  },
+  "footer": {
+    "copy": "© 2024 Alejandro Valencia. Full-stack Software Engineer based in Buenos Aires, Argentina."
+  },
+  "metadata": {
+    "title": "Alejandro Valencia | Product Engineer & Freelance Software Developer",
+    "description": "Freelance Product Engineer with 10+ years building scalable web apps. Specialized in React, Next.js, TypeScript. Delivering MVPs and full platforms for startups.",
+    "keywords": [
+      "freelance software engineer",
+      "product engineer",
+      "React developer",
+      "Next.js developer",
+      "TypeScript",
+      "startup MVP",
+      "web developer Buenos Aires",
+      "full-stack developer",
+      "Alejandro Valencia",
+      "valenciahq"
+    ]
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,14 @@
     "cert1Title": "Epic React",
     "cert1Provider": "Kent C. Dodds (epicreact.dev)",
     "cert2Title": "CSS-in-JS",
-    "cert2Provider": "Josh W. Comeau (css-for-js.dev)"
+    "cert2Provider": "Josh W. Comeau (css-for-js.dev)",
+    "cert3Title": "Claude Code 101",
+    "cert3Provider": "Anthropic (skilljar.com)",
+    "cert3Url": "https://anthropic.skilljar.com/claude-code-101",
+    "cert4Title": "Claude Code in Action",
+    "cert4Provider": "Anthropic (skilljar.com)",
+    "cert4Url": "https://anthropic.skilljar.com/claude-code-in-action",
+    "claudeCodeNote": "Daily user of Claude Code for AI-assisted development"
   },
   "contact": {
     "sectionTitle": "Let's Work Together",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,118 @@
+{
+  "nav": {
+    "contact": "Contacto",
+    "github": "GitHub"
+  },
+  "hero": {
+    "role": "Ingeniero de Producto",
+    "bio": "Más de 10 años de experiencia construyendo aplicaciones web escalables. Especializado en desarrollo Frontend con React y TypeScript desde 2017, entregando MVPs y plataformas completas para startups y equipos tecnológicos.",
+    "location": "Buenos Aires, Argentina",
+    "getInTouch": "Contactame",
+    "downloadResume": "Descargar CV"
+  },
+  "skills": {
+    "sectionTitle": "Habilidades",
+    "professionalTitle": "Habilidades Profesionales",
+    "languagesTitle": "Idiomas",
+    "spanish": "Español",
+    "spanishLevel": "Nativo",
+    "english": "Inglés",
+    "englishLevel": "B2/C1 Profesional",
+    "items": [
+      "Desarrollo Web Full-Stack",
+      "Prototipado Rápido y Entrega de MVPs",
+      "Pensamiento de Producto y Diseño Centrado en el Usuario",
+      "Escalabilidad y Mantenibilidad de Código",
+      "Colaboración Interfuncional",
+      "Metodologías Ágiles"
+    ]
+  },
+  "techStack": {
+    "sectionTitle": "Stack Tecnológico",
+    "cardTitle": "Tecnologías y Herramientas",
+    "cardDescription": "Tecnologías modernas que uso para construir aplicaciones escalables"
+  },
+  "experience": {
+    "sectionTitle": "Experiencia Laboral",
+    "jobs": [
+      {
+        "title": "Ingeniero Fundador",
+        "company": "Bondly",
+        "period": "09/24 - Presente",
+        "description": "Responsable del ciclo completo. Lanzé el consentimiento de cookies, reconstruí la herramienta de agendamiento y mejoré el SEO y tracking.",
+        "stack": "Next.js, Remix, NestJS, Supabase, TypeScript, herramientas AI"
+      },
+      {
+        "title": "Desarrollador Freelance",
+        "company": "Independiente",
+        "period": "2023 - Presente",
+        "description": "Construcción de aplicaciones web de alto rendimiento y MVPs. Colaboré con CTOs y CEOs en iniciativas de startups.",
+        "stack": "Next.js, React, TypeScript, Tailwind CSS, AWS Serverless"
+      },
+      {
+        "title": "Ingeniero Full Stack Senior",
+        "company": "StackZone",
+        "period": "03/22 - 08/23",
+        "description": "Mejoré la WebApp mediante refactoring, mentoría y buenas prácticas de TypeScript. Construí módulos de costos y APIs Serverless.",
+        "stack": "React, TypeScript, AWS, Redux-Saga, Cypress, PostgreSQL"
+      },
+      {
+        "title": "Lead Frontend Developer",
+        "company": "Commit Studio",
+        "period": "11/21 - 03/22",
+        "description": "Lideré el desarrollo de features y soporte al equipo. Entregué la plataforma de créditos (PedidosYa) y un CLI de e-commerce.",
+        "stack": "Next.js, TypeScript, MySQL, Redux-Toolkit"
+      },
+      {
+        "title": "Ingeniero de Software Senior",
+        "company": "Santander Tecnologia",
+        "period": "06/20 - 11/21",
+        "description": "Líder Frontend del equipo de Cheques. Construí micrositios y un BFF con NestJS. Lideré capacitación interna de React.",
+        "stack": "React, NestJS, TypeScript, Redux-Toolkit"
+      },
+      {
+        "title": "Ingeniero de Software",
+        "company": "ParkAssist",
+        "period": "06/20 - 11/21",
+        "description": "Desarrollé una plataforma de administración de estacionamientos con AWS y React. Entregué features de alto rendimiento.",
+        "stack": "React, TypeScript, Redux, AWS IAM, IoT, DynamoDB"
+      }
+    ]
+  },
+  "education": {
+    "sectionTitle": "Educación y Certificaciones",
+    "educationTitle": "Educación",
+    "degreeTitle": "Técnico Superior en Desarrollo de Software",
+    "degreeSchool": "ISTEA - Título Terciario",
+    "degreePeriod": "2014 - 2017",
+    "certificationsTitle": "Certificaciones",
+    "cert1Title": "Epic React",
+    "cert1Provider": "Kent C. Dodds (epicreact.dev)",
+    "cert2Title": "CSS-in-JS",
+    "cert2Provider": "Josh W. Comeau (css-for-js.dev)"
+  },
+  "contact": {
+    "sectionTitle": "Trabajemos Juntos",
+    "body": "¿Listo para construir algo increíble? Siempre estoy abierto a discutir nuevas oportunidades y proyectos interesantes.",
+    "githubLabel": "Perfil de GitHub"
+  },
+  "footer": {
+    "copy": "© 2024 Alejandro Valencia. Ingeniero de Software Full-Stack en Buenos Aires, Argentina."
+  },
+  "metadata": {
+    "title": "Alejandro Valencia | Ingeniero de Producto y Desarrollador Freelance",
+    "description": "Ingeniero de Producto Freelance con más de 10 años construyendo aplicaciones web escalables. Especializado en React, Next.js, TypeScript. MVPs y plataformas completas para startups.",
+    "keywords": [
+      "ingeniero de software freelance",
+      "ingeniero de producto",
+      "desarrollador React",
+      "desarrollador Next.js",
+      "TypeScript",
+      "startup MVP",
+      "desarrollador web Buenos Aires",
+      "desarrollador full-stack",
+      "Alejandro Valencia",
+      "valenciahq"
+    ]
+  }
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -89,7 +89,14 @@
     "cert1Title": "Epic React",
     "cert1Provider": "Kent C. Dodds (epicreact.dev)",
     "cert2Title": "CSS-in-JS",
-    "cert2Provider": "Josh W. Comeau (css-for-js.dev)"
+    "cert2Provider": "Josh W. Comeau (css-for-js.dev)",
+    "cert3Title": "Claude Code 101",
+    "cert3Provider": "Anthropic (skilljar.com)",
+    "cert3Url": "https://anthropic.skilljar.com/claude-code-101",
+    "cert4Title": "Claude Code in Action",
+    "cert4Provider": "Anthropic (skilljar.com)",
+    "cert4Url": "https://anthropic.skilljar.com/claude-code-in-action",
+    "claudeCodeNote": "Usuario diario de Claude Code para desarrollo asistido por IA"
   },
   "contact": {
     "sectionTitle": "Trabajemos Juntos",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.477.0",
     "motion": "^12.40.0",
     "next": "15.2.8",
+    "next-intl": "^4.13.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next:
         specifier: 15.2.8
         version: 15.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next-intl:
+        specifier: ^4.13.0
+        version: 4.13.0(next@15.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -111,6 +114,18 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.10':
+    resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -323,6 +338,88 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -382,11 +479,98 @@ packages:
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
 
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
+  '@swc/core-darwin-arm64@1.15.41':
+    resolution: {integrity: sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.41':
+    resolution: {integrity: sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    resolution: {integrity: sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    resolution: {integrity: sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    resolution: {integrity: sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    resolution: {integrity: sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.41':
+    resolution: {integrity: sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -1219,6 +1403,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  icu-minify@4.13.0:
+    resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1241,6 +1428,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  intl-messageformat@11.2.8:
+    resolution: {integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1511,6 +1701,23 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  next-intl-swc-plugin-extractor@4.13.0:
+    resolution: {integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==}
+
+  next-intl@4.13.0:
+    resolution: {integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   next@15.2.8:
     resolution: {integrity: sha512-pe2trLKZTdaCuvNER0S9Wp+SP2APf7SfFmyUP9/w1SFA2UqmW0u+IsxCKkiky3n6um7mryaQIlgiDnKrf1ZwIw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -1531,6 +1738,9 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -1640,6 +1850,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  po-parser@2.1.1:
+    resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2017,6 +2230,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-intl@4.13.0:
+    resolution: {integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2107,6 +2325,18 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.10
+
+  '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -2269,6 +2499,66 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2311,11 +2601,71 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@schummar/icu-type-parser@1.21.5': {}
+
+  '@swc/core-darwin-arm64@1.15.41':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core@1.15.41':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.41
+      '@swc/core-darwin-x64': 1.15.41
+      '@swc/core-linux-arm-gnueabihf': 1.15.41
+      '@swc/core-linux-arm64-gnu': 1.15.41
+      '@swc/core-linux-arm64-musl': 1.15.41
+      '@swc/core-linux-ppc64-gnu': 1.15.41
+      '@swc/core-linux-s390x-gnu': 1.15.41
+      '@swc/core-linux-x64-gnu': 1.15.41
+      '@swc/core-linux-x64-musl': 1.15.41
+      '@swc/core-win32-arm64-msvc': 1.15.41
+      '@swc/core-win32-ia32-msvc': 1.15.41
+      '@swc/core-win32-x64-msvc': 1.15.41
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -2771,8 +3121,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -3279,6 +3628,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  icu-minify@4.13.0:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.11
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -3300,6 +3653,11 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  intl-messageformat@11.2.8:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3556,6 +3914,27 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
+  next-intl-swc-plugin-extractor@4.13.0: {}
+
+  next-intl@4.13.0(next@15.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@5.9.3):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.8.10
+      '@parcel/watcher': 2.5.6
+      '@swc/core': 1.15.41
+      icu-minify: 4.13.0
+      negotiator: 1.0.0
+      next: 15.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next-intl-swc-plugin-extractor: 4.13.0
+      po-parser: 2.1.1
+      react: 19.2.7
+      use-intl: 4.13.0(react@19.2.7)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   next@15.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.2.8
@@ -3580,6 +3959,8 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-addon-api@7.1.1: {}
 
   node-exports-info@1.6.0:
     dependencies:
@@ -3689,6 +4070,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  po-parser@2.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -4186,6 +4569,14 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-intl@4.13.0(react@19.2.7):
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@schummar/icu-type-parser': 1.21.5
+      icu-minify: 4.13.0
+      intl-messageformat: 11.2.8
+      react: 19.2.7
 
   util-deprecate@1.0.2: {}
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getTranslations } from "next-intl/server";
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import { routing } from "@/i18n/routing";
+
+const SITE_URL = "https://www.valenciahq.com";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "metadata" });
+
+  return {
+    metadataBase: new URL(SITE_URL),
+    title: t("title"),
+    description: t("description"),
+    keywords: t.raw("keywords") as string[],
+    authors: [{ name: "Alejandro Valencia", url: SITE_URL }],
+    creator: "Alejandro Valencia",
+    publisher: "Alejandro Valencia",
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true, "max-image-preview": "large" },
+    },
+    alternates: {
+      canonical: `${SITE_URL}/${locale}`,
+      languages: {
+        en: `${SITE_URL}/en`,
+        es: `${SITE_URL}/es`,
+        "x-default": `${SITE_URL}/en`,
+      },
+    },
+    openGraph: {
+      type: "website",
+      url: `${SITE_URL}/${locale}`,
+      siteName: "Alejandro Valencia",
+      title: t("title"),
+      description: t("description"),
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: "Alejandro Valencia — Product Engineer",
+        },
+      ],
+      locale: locale === "es" ? "es_ES" : "en_US",
+      alternateLocale: locale === "es" ? "en_US" : "es_ES",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@_valenciaHQ",
+      creator: "@_valenciaHQ",
+      title: t("title"),
+      description: t("description"),
+      images: ["/opengraph-image"],
+    },
+  };
+}
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  if (!routing.locales.includes(locale as "en" | "es")) {
+    notFound();
+  }
+
+  const messages = await getMessages();
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Alejandro Valencia",
+    url: SITE_URL,
+    jobTitle: locale === "es" ? "Ingeniero de Producto" : "Product Engineer",
+    description:
+      locale === "es"
+        ? "Ingeniero de Producto Freelance con más de 10 años construyendo aplicaciones web escalables con React, Next.js y TypeScript."
+        : "Freelance Product Engineer with 10+ years building scalable web applications using React, Next.js, and TypeScript.",
+    email: "alejandro.d.valencia@gmail.com",
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Buenos Aires",
+      addressCountry: "AR",
+    },
+    sameAs: [
+      "https://github.com/valenciaHQ",
+      "https://www.linkedin.com/in/valenciaalejandro/",
+      "https://twitter.com/_valenciaHQ",
+    ],
+    knowsAbout: [
+      "React",
+      "Next.js",
+      "TypeScript",
+      "Node.js",
+      "Full-Stack Development",
+      "MVP Development",
+      "Software Architecture",
+    ],
+  };
+
+  return (
+    <html lang={locale}>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
+      <body>
+        <NextIntlClientProvider messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+        <Analytics />
+        <SpeedInsights />
+      </body>
+    </html>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 /** @format */
 
+import { useTranslations } from "next-intl";
 import { motion } from "motion/react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,88 +27,42 @@ import {
 import { EnvelopeClosedIcon, CalendarIcon } from "@radix-ui/react-icons";
 import { AnimatedGrid, AnimatedItem } from "@/components/ui/AnimatedSection";
 import { staggerContainer, fadeSlideUp } from "@/lib/animations";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+import { HeroBlobs } from "@/components/HeroBlobs";
+
+const techStack = [
+  "JavaScript",
+  "TypeScript",
+  "React.js",
+  "Next.js",
+  "Remix",
+  "Node.js",
+  "Express.js",
+  "NestJS",
+  "PostgreSQL",
+  "Supabase",
+  "MongoDB",
+  "Redux Toolkit",
+  "Zustand",
+  "Tailwind CSS",
+  "AWS",
+  "Vercel",
+  "Cypress",
+  "Jest",
+];
+
+type Job = {
+  title: string;
+  company: string;
+  period: string;
+  description: string;
+  stack: string;
+};
 
 export default function Portfolio() {
-  const techStack = [
-    "JavaScript",
-    "TypeScript",
-    "React.js",
-    "Next.js",
-    "Remix",
-    "Node.js",
-    "Express.js",
-    "NestJS",
-    "PostgreSQL",
-    "Supabase",
-    "MongoDB",
-    "Redux Toolkit",
-    "Zustand",
-    "Tailwind CSS",
-    "AWS",
-    "Vercel",
-    "Cypress",
-    "Jest",
-  ];
-
-  const skills = [
-    "Full-Stack Web Development",
-    "Rapid Prototyping & MVP Delivery",
-    "Product Thinking & User-Centered Design",
-    "Codebase Scalability & Maintainability",
-    "Cross-functional Collaboration",
-    "Agile Methodologies",
-  ];
-
-  const workExperience = [
-    {
-      title: "Founding Engineer",
-      company: "Bondly",
-      period: "09/24 - Present",
-      description:
-        "Owned full lifecycle. Launched cookie consent, rebuilt scheduling tool, improved SEO and tracking.",
-      stack: "Next.js, Remix, NestJS, Supabase, TypeScript, AI tools",
-    },
-    {
-      title: "Freelance Developer",
-      company: "Independent",
-      period: "2023 - Present",
-      description:
-        "Building high-performance web applications and MVPs. Collaborated with CTOs and CEOs on startup initiatives.",
-      stack: "Next.js, React, TypeScript, Tailwind CSS, AWS Serverless",
-    },
-    {
-      title: "Senior Full Stack Engineer",
-      company: "StackZone",
-      period: "03/22 - 08/23",
-      description:
-        "Improved WebApp via refactoring, mentoring, and TS best practices. Built cost modules and Serverless APIs.",
-      stack: "React, TypeScript, AWS, Redux-Saga, Cypress, PostgreSQL",
-    },
-    {
-      title: "Lead Frontend Developer",
-      company: "Commit Studio",
-      period: "11/21 - 03/22",
-      description:
-        "Led feature development and team support. Delivered credit partner platform (PedidosYa) and e-commerce CLI.",
-      stack: "Next.js, TypeScript, MySQL, Redux-Toolkit",
-    },
-    {
-      title: "Sr Software Engineer",
-      company: "Santander Tecnologia",
-      period: "06/20 - 11/21",
-      description:
-        "Frontend lead for Checks team. Built microsites and BFF with NestJS. Led internal React training.",
-      stack: "React, NestJS, TypeScript, Redux-Toolkit",
-    },
-    {
-      title: "Software Engineer",
-      company: "ParkAssist",
-      period: "06/20 - 11/21",
-      description:
-        "Developed parking admin platform using AWS and React. Delivered performant client-side features.",
-      stack: "React, TypeScript, Redux, AWS IAM, IoT, DynamoDB",
-    },
-  ];
+  const t = useTranslations();
+  const skills = t.raw("skills.items") as string[];
+  const workExperience = t.raw("experience.jobs") as Job[];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
@@ -118,22 +73,27 @@ export default function Portfolio() {
             <h1 className="text-2xl font-bold text-gray-900">
               Alejandro Valencia
             </h1>
-            <div className="flex gap-4">
-              <Button
-                variant="outline"
-                className="bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-                onClick={() => { window.location.href = "mailto:alejandro.d.valencia@gmail.com"; }}
+            <div className="flex gap-4 items-center">
+              <LocaleSwitcher />
+              <a href="mailto:alejandro.d.valencia@gmail.com">
+                <Button
+                  variant="outline"
+                  className="bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                >
+                  <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
+                  {t("nav.contact")}
+                </Button>
+              </a>
+              <a
+                href="https://github.com/valenciaHQ"
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
-                Contact
-              </Button>
-              <Button
-                className="bg-gray-900 text-white hover:bg-gray-800"
-                onClick={() => { window.open("https://github.com/valenciaHQ", "_blank"); }}
-              >
-                <Github className="w-4 h-4 mr-2" />
-                GitHub
-              </Button>
+                <Button className="bg-gray-900 text-white hover:bg-gray-800">
+                  <Github className="w-4 h-4 mr-2" />
+                  {t("nav.github")}
+                </Button>
+              </a>
             </div>
           </nav>
         </div>
@@ -141,22 +101,7 @@ export default function Portfolio() {
 
       {/* Hero Section */}
       <section className="relative py-20 px-4 overflow-hidden">
-        {/* Animated color blobs */}
-        <motion.div
-          className="absolute top-10 left-1/4 w-72 h-72 rounded-full bg-violet-300 opacity-30 blur-3xl pointer-events-none"
-          animate={{ x: [0, 40, -20, 0], y: [0, -30, 20, 0], scale: [1, 1.1, 0.95, 1] }}
-          transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
-        />
-        <motion.div
-          className="absolute top-20 right-1/4 w-80 h-80 rounded-full bg-sky-300 opacity-25 blur-3xl pointer-events-none"
-          animate={{ x: [0, -50, 30, 0], y: [0, 40, -20, 0], scale: [1, 0.9, 1.15, 1] }}
-          transition={{ duration: 13, repeat: Infinity, ease: "easeInOut", delay: 1 }}
-        />
-        <motion.div
-          className="absolute bottom-0 left-1/3 w-64 h-64 rounded-full bg-emerald-300 opacity-20 blur-3xl pointer-events-none"
-          animate={{ x: [0, 30, -40, 0], y: [0, -20, 30, 0], scale: [1, 1.2, 0.9, 1] }}
-          transition={{ duration: 11, repeat: Infinity, ease: "easeInOut", delay: 2 }}
-        />
+        <HeroBlobs />
 
         <div className="relative max-w-6xl mx-auto text-center">
           <motion.div
@@ -173,13 +118,10 @@ export default function Portfolio() {
                 Alejandro Valencia
               </h1>
               <p className="text-xl md:text-2xl text-gray-600 mb-6">
-                Product Engineer
+                {t("hero.role")}
               </p>
               <p className="text-lg text-gray-500 max-w-3xl mx-auto leading-relaxed">
-                10+ years of experience building scalable web applications.
-                Specialized in Frontend development with React and TypeScript
-                since 2017, delivering MVPs and full platforms for startups and
-                tech-driven teams.
+                {t("hero.bio")}
               </p>
             </motion.div>
 
@@ -190,7 +132,7 @@ export default function Portfolio() {
             >
               <div className="flex items-center gap-2 text-gray-600">
                 <MapPin className="w-4 h-4" />
-                <span>Buenos Aires, Argentina</span>
+                <span>{t("hero.location")}</span>
               </div>
               <div className="flex items-center gap-2 text-gray-600">
                 <EnvelopeClosedIcon className="w-4 h-4" />
@@ -207,18 +149,16 @@ export default function Portfolio() {
               variants={fadeSlideUp}
               transition={{ duration: 0.5, ease: "easeOut" }}
             >
-              <Button
-                size="lg"
-                variant="outline"
-                className="bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-                onClick={() => {
-                  window.location.href =
-                    "mailto:alejandro.d.valencia@gmail.com";
-                }}
-              >
-                <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
-                Get In Touch
-              </Button>
+              <a href="mailto:alejandro.d.valencia@gmail.com">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                >
+                  <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
+                  {t("hero.getInTouch")}
+                </Button>
+              </a>
               <motion.a
                 href="/files/alejandrovalencia.pdf"
                 download="alejandro-valencia-resume.pdf"
@@ -229,15 +169,24 @@ export default function Portfolio() {
                 <motion.span
                   className="flex items-center"
                   animate={{ y: [0, -2, 0] }}
-                  transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+                  transition={{
+                    duration: 1.8,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                  }}
                 >
                   <FileText className="w-4 h-4" />
                 </motion.span>
-                Download Resume
+                {t("hero.downloadResume")}
                 <motion.span
                   className="text-xs opacity-60 group-hover:opacity-100 transition-opacity"
                   animate={{ y: [0, 2, 0] }}
-                  transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut", delay: 0.9 }}
+                  transition={{
+                    duration: 1.8,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                    delay: 0.9,
+                  }}
                 >
                   PDF
                 </motion.span>
@@ -251,7 +200,7 @@ export default function Portfolio() {
       <section className="py-16 px-4 bg-white">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
-            Core Skills
+            {t("skills.sectionTitle")}
           </h2>
           <AnimatedGrid className="grid md:grid-cols-2 gap-8">
             <AnimatedItem>
@@ -259,7 +208,7 @@ export default function Portfolio() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Star className="w-5 h-5 text-yellow-500" />
-                    Professional Skills
+                    {t("skills.professionalTitle")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -283,21 +232,21 @@ export default function Portfolio() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Languages className="w-5 h-5 text-green-500" />
-                    Languages
+                    {t("skills.languagesTitle")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
                     <div className="flex justify-between items-center">
-                      <span className="font-medium">Spanish</span>
+                      <span className="font-medium">{t("skills.spanish")}</span>
                       <Badge className="bg-green-100 text-green-800">
-                        Native
+                        {t("skills.spanishLevel")}
                       </Badge>
                     </div>
                     <div className="flex justify-between items-center">
-                      <span className="font-medium">English</span>
+                      <span className="font-medium">{t("skills.english")}</span>
                       <Badge className="bg-blue-100 text-blue-800">
-                        B2/C1 Professional
+                        {t("skills.englishLevel")}
                       </Badge>
                     </div>
                   </div>
@@ -312,7 +261,7 @@ export default function Portfolio() {
       <section className="py-16 px-4">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
-            Tech Stack
+            {t("techStack.sectionTitle")}
           </h2>
           <AnimatedGrid className="grid grid-cols-1">
             <AnimatedItem>
@@ -320,10 +269,10 @@ export default function Portfolio() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Code className="w-5 h-5 text-purple-500" />
-                    Technologies & Tools
+                    {t("techStack.cardTitle")}
                   </CardTitle>
                   <CardDescription>
-                    Modern technologies I use to build scalable applications
+                    {t("techStack.cardDescription")}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -349,7 +298,7 @@ export default function Portfolio() {
       <section className="py-16 px-4 bg-white">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
-            Work Experience
+            {t("experience.sectionTitle")}
           </h2>
           <AnimatedGrid className="space-y-6">
             {workExperience.map((job, index) => (
@@ -394,7 +343,7 @@ export default function Portfolio() {
       <section className="py-16 px-4">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
-            Education & Certifications
+            {t("education.sectionTitle")}
           </h2>
           <AnimatedGrid className="grid md:grid-cols-2 gap-6">
             <AnimatedItem>
@@ -402,16 +351,18 @@ export default function Portfolio() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <GraduationCap className="w-5 h-5 text-blue-500" />
-                    Education
+                    {t("education.educationTitle")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div>
                     <h3 className="font-semibold text-lg">
-                      Superior Software Development Technician
+                      {t("education.degreeTitle")}
                     </h3>
-                    <p className="text-gray-600">ISTEA - Tertiary Degree</p>
-                    <p className="text-sm text-gray-500">2014 - 2017</p>
+                    <p className="text-gray-600">{t("education.degreeSchool")}</p>
+                    <p className="text-sm text-gray-500">
+                      {t("education.degreePeriod")}
+                    </p>
                   </div>
                 </CardContent>
               </Card>
@@ -422,22 +373,22 @@ export default function Portfolio() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Award className="w-5 h-5 text-orange-500" />
-                    Certifications
+                    {t("education.certificationsTitle")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
                     <div>
-                      <h3 className="font-semibold">Epic React</h3>
+                      <h3 className="font-semibold">{t("education.cert1Title")}</h3>
                       <p className="text-sm text-gray-600">
-                        Kent C. Dodds (epicreact.dev)
+                        {t("education.cert1Provider")}
                       </p>
                     </div>
                     <Separator />
                     <div>
-                      <h3 className="font-semibold">CSS-in-JS</h3>
+                      <h3 className="font-semibold">{t("education.cert2Title")}</h3>
                       <p className="text-sm text-gray-600">
-                        Josh W. Comeau (css-for-js.dev)
+                        {t("education.cert2Provider")}
                       </p>
                     </div>
                   </div>
@@ -451,23 +402,19 @@ export default function Portfolio() {
       {/* Contact Section */}
       <section className="py-16 px-4 bg-gray-900 text-white">
         <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-3xl font-bold mb-6">Let&#39;s Work Together</h2>
-          <p className="text-xl text-gray-300 mb-8">
-            Ready to build something amazing? I&#39;m always open to discussing
-            new opportunities and interesting projects.
-          </p>
+          <h2 className="text-3xl font-bold mb-6">{t("contact.sectionTitle")}</h2>
+          <p className="text-xl text-gray-300 mb-8">{t("contact.body")}</p>
           <div className="flex flex-wrap justify-center gap-4">
-            <Button
-              size="lg"
-              variant="outline"
-              className="bg-transparent text-white border-white hover:bg-white hover:text-gray-900"
-              onClick={() => {
-                window.location.href = "mailto:alejandro.d.valencia@gmail.com";
-              }}
-            >
-              <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
-              alejandro.d.valencia@gmail.com
-            </Button>
+            <a href="mailto:alejandro.d.valencia@gmail.com">
+              <Button
+                size="lg"
+                variant="outline"
+                className="bg-transparent text-white border-white hover:bg-white hover:text-gray-900"
+              >
+                <EnvelopeClosedIcon className="w-4 h-4 mr-2" />
+                alejandro.d.valencia@gmail.com
+              </Button>
+            </a>
             <Button
               size="lg"
               variant="outline"
@@ -476,17 +423,20 @@ export default function Portfolio() {
               <Globe className="w-4 h-4 mr-2" />
               valenciahq.com
             </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              className="bg-transparent text-white border-white hover:bg-white hover:text-gray-900"
-              onClick={() => {
-                window.open("https://github.com/valenciaHQ", "_blank");
-              }}
+            <a
+              href="https://github.com/valenciaHQ"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <Github className="w-4 h-4 mr-2" />
-              GitHub Profile
-            </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="bg-transparent text-white border-white hover:bg-white hover:text-gray-900"
+              >
+                <Github className="w-4 h-4 mr-2" />
+                {t("contact.githubLabel")}
+              </Button>
+            </a>
           </div>
         </div>
       </section>
@@ -494,10 +444,7 @@ export default function Portfolio() {
       {/* Footer */}
       <footer className="py-8 px-4 bg-gray-800 text-gray-400">
         <div className="max-w-6xl mx-auto text-center">
-          <p>
-            &copy; 2024 Alejandro Valencia. Full-stack Software Engineer based
-            in Buenos Aires, Argentina.
-          </p>
+          <p>{t("footer.copy")}</p>
         </div>
       </footer>
     </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -49,6 +49,7 @@ const techStack = [
   "Vercel",
   "Cypress",
   "Jest",
+  "Claude Code",
 ];
 
 type Job = {
@@ -389,6 +390,37 @@ export default function Portfolio() {
                       <h3 className="font-semibold">{t("education.cert2Title")}</h3>
                       <p className="text-sm text-gray-600">
                         {t("education.cert2Provider")}
+                      </p>
+                    </div>
+                    <Separator />
+                    <div>
+                      <a
+                        href={t("education.cert3Url")}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline"
+                      >
+                        <h3 className="font-semibold">{t("education.cert3Title")}</h3>
+                      </a>
+                      <p className="text-sm text-gray-600">
+                        {t("education.cert3Provider")}
+                      </p>
+                    </div>
+                    <Separator />
+                    <div>
+                      <a
+                        href={t("education.cert4Url")}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline"
+                      >
+                        <h3 className="font-semibold">{t("education.cert4Title")}</h3>
+                      </a>
+                      <p className="text-sm text-gray-600">
+                        {t("education.cert4Provider")}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-1">
+                        {t("education.claudeCodeNote")}
                       </p>
                     </div>
                   </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,57 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import { Analytics } from "@vercel/analytics/react";
-import { SpeedInsights } from "@vercel/speed-insights/next";
-
-const SITE_URL = "https://www.valenciahq.com";
-
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_URL),
-  title: "Alejandro Valencia | Product Engineer & Freelance Software Developer",
-  description:
-    "Freelance Product Engineer with 10+ years building scalable web apps. Specialized in React, Next.js, TypeScript. Delivering MVPs and full platforms for startups.",
-  keywords: [
-    "freelance software engineer",
-    "product engineer",
-    "React developer",
-    "Next.js developer",
-    "TypeScript",
-    "startup MVP",
-    "web developer Buenos Aires",
-    "full-stack developer",
-    "Alejandro Valencia",
-    "valenciahq",
-  ],
-  authors: [{ name: "Alejandro Valencia", url: SITE_URL }],
-  creator: "Alejandro Valencia",
-  publisher: "Alejandro Valencia",
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: { index: true, follow: true, "max-image-preview": "large" },
-  },
-  alternates: { canonical: SITE_URL },
-  openGraph: {
-    type: "website",
-    url: SITE_URL,
-    siteName: "Alejandro Valencia",
-    title: "Alejandro Valencia | Product Engineer & Freelance Software Developer",
-    description:
-      "Freelance Product Engineer with 10+ years building scalable web apps. React, Next.js, TypeScript. MVPs and full platforms for startups.",
-    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "Alejandro Valencia — Product Engineer" }],
-    locale: "en_US",
-  },
-  twitter: {
-    card: "summary_large_image",
-    site: "@_valenciaHQ",
-    creator: "@_valenciaHQ",
-    title: "Alejandro Valencia | Product Engineer & Freelance Software Developer",
-    description:
-      "Freelance Product Engineer with 10+ years building scalable web apps. React, Next.js, TypeScript.",
-    images: ["/opengraph-image"],
-  },
-};
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -64,55 +13,19 @@ const geistMono = localFont({
   weight: "100 900",
 });
 
+export const metadata: Metadata = {
+  robots: { index: true, follow: true },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    name: "Alejandro Valencia",
-    url: SITE_URL,
-    jobTitle: "Product Engineer",
-    description:
-      "Freelance Product Engineer with 10+ years building scalable web applications using React, Next.js, and TypeScript.",
-    email: "alejandro.d.valencia@gmail.com",
-    address: {
-      "@type": "PostalAddress",
-      addressLocality: "Buenos Aires",
-      addressCountry: "AR",
-    },
-    sameAs: [
-      "https://github.com/valenciaHQ",
-      "https://www.linkedin.com/in/valenciaalejandro/",
-      "https://twitter.com/_valenciaHQ",
-    ],
-    knowsAbout: [
-      "React",
-      "Next.js",
-      "TypeScript",
-      "Node.js",
-      "Full-Stack Development",
-      "MVP Development",
-      "Software Architecture",
-    ],
-  };
-
   return (
-    <html lang="en">
-      <head>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-      </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,13 @@
 import type { MetadataRoute } from "next";
 
+const SITE_URL = "https://www.valenciahq.com";
+const locales = ["en", "es"] as const;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: "https://www.valenciahq.com",
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 1,
-    },
-  ];
+  return locales.map((locale) => ({
+    url: `${SITE_URL}/${locale}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: locale === "en" ? 1 : 0.9,
+  }));
 }

--- a/src/components/HeroBlobs.tsx
+++ b/src/components/HeroBlobs.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { motion } from 'motion/react';
+
+export function HeroBlobs() {
+  return (
+    <>
+      <motion.div
+        className="absolute top-10 left-1/4 w-72 h-72 rounded-full bg-violet-300 opacity-30 blur-3xl pointer-events-none"
+        animate={{ x: [0, 40, -20, 0], y: [0, -30, 20, 0], scale: [1, 1.1, 0.95, 1] }}
+        transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.div
+        className="absolute top-20 right-1/4 w-80 h-80 rounded-full bg-sky-300 opacity-25 blur-3xl pointer-events-none"
+        animate={{ x: [0, -50, 30, 0], y: [0, 40, -20, 0], scale: [1, 0.9, 1.15, 1] }}
+        transition={{ duration: 13, repeat: Infinity, ease: "easeInOut", delay: 1 }}
+      />
+      <motion.div
+        className="absolute bottom-0 left-1/3 w-64 h-64 rounded-full bg-emerald-300 opacity-20 blur-3xl pointer-events-none"
+        animate={{ x: [0, 30, -40, 0], y: [0, -20, 30, 0], scale: [1, 1.2, 0.9, 1] }}
+        transition={{ duration: 11, repeat: Infinity, ease: "easeInOut", delay: 2 }}
+      />
+    </>
+  );
+}

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useLocale } from 'next-intl';
+import { useRouter, usePathname } from '@/i18n/navigation';
+import { useTransition } from 'react';
+import { routing } from '@/i18n/routing';
+
+export function LocaleSwitcher() {
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  function switchLocale(next: string) {
+    startTransition(() => {
+      router.replace(pathname, { locale: next as typeof routing.locales[number] });
+      document.cookie = `NEXT_LOCALE=${next}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    });
+  }
+
+  return (
+    <button
+      onClick={() => switchLocale(locale === 'en' ? 'es' : 'en')}
+      disabled={isPending}
+      className="text-sm font-medium text-gray-600 hover:text-gray-900 border border-gray-300 rounded px-2 py-1 transition-colors hover:bg-gray-50 disabled:opacity-50"
+      aria-label="Switch language"
+    >
+      {locale === 'en' ? 'ES' : 'EN'}
+    </button>
+  );
+}

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,0 +1,4 @@
+import { createNavigation } from 'next-intl/navigation';
+import { routing } from './routing';
+
+export const { Link, redirect, usePathname, useRouter } = createNavigation(routing);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,13 @@
+import { getRequestConfig } from 'next-intl/server';
+import { routing } from './routing';
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+  if (!locale || !routing.locales.includes(locale as 'en' | 'es')) {
+    locale = routing.defaultLocale;
+  }
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,6 @@
+import { defineRouting } from 'next-intl/routing';
+
+export const routing = defineRouting({
+  locales: ['en', 'es'],
+  defaultLocale: 'en',
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,53 @@
+import createMiddleware from 'next-intl/middleware';
+import { type NextRequest, NextResponse } from 'next/server';
+import { routing } from './i18n/routing';
+
+const intlMiddleware = createMiddleware(routing);
+
+const SPANISH_COUNTRIES = new Set([
+  'ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'VE', 'EC',
+  'BO', 'PY', 'UY', 'CR', 'PA', 'DO', 'GT', 'HN',
+  'SV', 'NI', 'CU', 'PR',
+]);
+const LOCALE_COOKIE = 'NEXT_LOCALE';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const localeCookie = request.cookies.get(LOCALE_COOKIE)?.value;
+  const hasLocalePrefix = routing.locales.some(
+    (l) => pathname === `/${l}` || pathname.startsWith(`/${l}/`)
+  );
+
+  if (localeCookie || hasLocalePrefix) {
+    return intlMiddleware(request);
+  }
+
+  if (pathname === '/') {
+    const geo = (request as NextRequest & { geo?: { country?: string } }).geo;
+    const country = geo?.country?.toUpperCase();
+    const acceptLang = request.headers.get('accept-language') ?? '';
+    const primaryLang = acceptLang.split(',')[0]?.split('-')[0]?.toLowerCase();
+
+    const isSpanish =
+      (country && SPANISH_COUNTRIES.has(country)) ||
+      (!country && primaryLang === 'es');
+
+    const targetLocale = isSpanish ? 'es' : 'en';
+    const url = request.nextUrl.clone();
+    url.pathname = `/${targetLocale}`;
+
+    const res = NextResponse.redirect(url);
+    res.cookies.set(LOCALE_COOKIE, targetLocale, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+    });
+    return res;
+  }
+
+  return intlMiddleware(request);
+}
+
+export const config = {
+  matcher: ['/((?!_next|api|.*\\..*).*)'],
+};


### PR DESCRIPTION
- Add next-intl with /en and /es routes via [locale] App Router segment
- Middleware auto-redirects / based on Vercel geo (IP) or Accept-Language header
- Cookie NEXT_LOCALE persists user's explicit locale choice for 1 year
- LocaleSwitcher component in nav for manual toggle
- Extract HeroBlobs to client component, page.tsx uses useTranslations
- ~100 strings translated in messages/en.json and messages/es.json
- Locale-aware metadata, hreflang alternates, html lang attribute
- Sitemap updated with both /en and /es routes
- Both locales statically generated at build time