### PR TITLE
fix: prevent stale closure crash in Terminal typing effect

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -57,9 +57,10 @@ export default function Terminal() {
           lineIndex = 0;
           continue;
         }
-        await typeLine(LINES[lineIndex].text);
+        const line = LINES[lineIndex].text;
+        await typeLine(line);
         if (cancelled) return;
-        setShown((prev) => [...prev, LINES[lineIndex].text]);
+        setShown((prev) => [...prev, line]);
         setTyping("");
         lineIndex++;
         await new Promise((r) => setTimeout(r, 260));


### PR DESCRIPTION
## Summary
- Terminal.tsx crashed with `Cannot read properties of undefined (reading 'text')` — the `setShown` updater closed over the mutable `lineIndex` variable instead of a snapshot, so a deferred/replayed React state update could read `LINES[lineIndex]` after `lineIndex++` already advanced past the array bounds.
- Fix: capture `LINES[lineIndex].text` into a local `const line` before scheduling the state update.

## Test plan
- [ ] `pnpm dev`, load homepage, confirm Terminal component types through all lines and loops without console errors
- [ ] Verify in React StrictMode (dev) — no more `Cannot read properties of undefined` crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)