### PR TITLE
feat: favicon/OG dinámicos, CTA WhatsApp y precios de growth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# dependencies
+/node_modules
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# claude code local config
+.claude/
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Stack
+
+- Next.js 16 (App Router, Turbopack)
+- React 19, TypeScript (strict)
+- Tailwind CSS v4 — config lives in `app/globals.css` via `@theme`, no `tailwind.config.ts`
+- Fonts: Space Grotesk (display), Inter (body), JetBrains Mono (mono) via `next/font/google`
+
+## Package manager
+
+This project uses **npm** (`package-lock.json` is committed) — not pnpm, despite the global default in `~/CLAUDE.md`.
+
+```bash
+npm install
+npm run dev      # http://localhost:3000
+npm run build
+npm run lint
+```
+
+## Structure
+
+- `app/layout.tsx` — metadata, fonts, JSON-LD (`ProfessionalService` schema)
+- `app/page.tsx` — assembles page sections in order
+- `app/sitemap.ts`, `app/robots.ts` — auto-generated SEO routes
+- `app/icon.tsx`, `app/opengraph-image.tsx` — dynamic favicon/OG image via `next/og` (no static image assets, generated at request time)
+- `components/` — one section per file: `Nav`, `Hero`, `Terminal`, `Services`, `SeoDiff`, `Process`, `StackSection`, `Addons`, `PortfolioRate`, `Contact`, `Footer`, `Reveal`
+- `lib/site-config.ts` — single source of truth for domain, email, WhatsApp number, location; edit here, not inline in components
+
+## Conventions
+
+- Site content and copy are in Spanish — target audience is small/local Argentine businesses that lack a website or need a basic growth/SEO strategy
+- Design tokens (colors) are CSS vars in `app/globals.css`, exposed to Tailwind via `@theme inline`
+- Pricing/services content lives as typed arrays at the top of `components/Services.tsx` and `components/Addons.tsx`
+- No shadcn/ui, no Radix, no `tailwind.config.ts` — plain Tailwind v4 + hand-rolled components

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ npm run dev
       permanente (ver nota de SEO: subdominios no heredan la autoridad del
       dominio raíz).
 - [ ] Reemplazar el email/GitHub en `site-config.ts` si cambian.
-- [ ] Agregar una imagen Open Graph real (`public/og.png`, 1200×630) y
-      referenciarla en `app/layout.tsx` → `metadata.openGraph.images`. Sin
-      esto, los links compartidos en WhatsApp/LinkedIn no muestran preview.
+- [x] Imagen Open Graph: generada dinámicamente en `app/opengraph-image.tsx`
+      (vía `next/og`), Next la asocia automáticamente a `metadata`. Favicon
+      dinámico en `app/icon.tsx` con el mismo mecanismo.
 - [ ] `npm run build` local antes de mergear, para confirmar que compila con
       acceso normal a internet (fonts de Google se resuelven en build time).
 

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0b0f17",
+          borderRadius: 7,
+          fontFamily: "monospace",
+          fontSize: 20,
+          fontWeight: 700,
+          color: "#2fe28a",
+        }}
+      >
+        {"›"}
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from "next/og";
+import { siteConfig } from "@/lib/site-config";
+
+export const alt = siteConfig.title;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "90px",
+          background: "linear-gradient(135deg, #0b0f17 0%, #141b29 100%)",
+          fontFamily: "monospace",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            letterSpacing: -0.3,
+            color: "#2fe28a",
+            marginBottom: 28,
+          }}
+        >
+          software a medida · seo técnico · buenos aires
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 68,
+            fontWeight: 700,
+            color: "#ffffff",
+            lineHeight: 1.15,
+          }}
+        >
+          valencia
+          <span style={{ color: "#2fe28a" }}>://</span>
+          hq
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 27,
+            color: "#8a93a6",
+            marginTop: 32,
+            maxWidth: 840,
+          }}
+        >
+          Ingeniería, no artesanía improvisada. Landing pages, sitios
+          institucionales y SEO técnico para negocios chicos.
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/components/Addons.tsx
+++ b/components/Addons.tsx
@@ -1,30 +1,27 @@
 import Reveal from "./Reveal";
 
-const ADDONS = [
-  {
-    title: "Auditoría y Remediación SEO",
-    desc: "Análisis de rendimiento e indexación, one-off",
-    price: "USD 150–250",
-  },
+const FEATURED_ADDON = {
+  title: "Auditoría y Remediación SEO",
+  desc: "Análisis de rendimiento e indexación, one-off",
+  price: "USD 150–250",
+};
+
+const OTHER_ADDONS = [
   {
     title: "Crecimiento Orgánico Continuo",
     desc: "Retainer mensual, incluye hosting",
-    price: "USD 150–300/mes",
   },
   {
     title: "Ficha de Google Business",
     desc: "Reclamo, categorías, fotos y posts iniciales",
-    price: "USD 100–150",
   },
   {
     title: "Gestión de Reputación Online",
     desc: "Monitoreo y respuesta a reseñas",
-    price: "USD 100–200/mes",
   },
   {
     title: "Campañas Meta Ads",
     desc: "Segmentación local y reporte mensual",
-    price: "USD 150–300/mes + pauta",
   },
 ];
 
@@ -45,19 +42,28 @@ export default function Addons() {
           </p>
         </Reveal>
 
-        <Reveal className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {ADDONS.map((a) => (
+        <Reveal className="mb-5 flex flex-col items-start justify-between gap-4 rounded-[10px] border border-ink bg-card p-7 sm:flex-row sm:items-center">
+          <div>
+            <h3 className="mb-1.5 text-[19px] font-bold">
+              {FEATURED_ADDON.title}
+            </h3>
+            <p className="text-[13.5px] text-muted">{FEATURED_ADDON.desc}</p>
+          </div>
+          <span className="whitespace-nowrap font-mono text-[22px] font-semibold text-signal-deep">
+            {FEATURED_ADDON.price}
+          </span>
+        </Reveal>
+
+        <Reveal className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {OTHER_ADDONS.map((a) => (
             <div
               key={a.title}
-              className="flex items-center justify-between gap-4 rounded-[10px] border border-line bg-white px-5 py-5"
+              className="rounded-[10px] border border-line px-5 py-4"
             >
-              <div>
-                <h4 className="mb-1 text-[14.5px] font-semibold">{a.title}</h4>
-                <p className="text-[12.5px] text-muted">{a.desc}</p>
-              </div>
-              <span className="whitespace-nowrap font-mono text-[13px] font-semibold text-signal-deep">
-                {a.price}
-              </span>
+              <h4 className="mb-1 text-[13.5px] font-semibold text-muted">
+                {a.title}
+              </h4>
+              <p className="text-[12px] text-muted">{a.desc}</p>
             </div>
           ))}
         </Reveal>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,5 @@
 import Terminal from "./Terminal";
+import { whatsappUrl } from "@/lib/site-config";
 
 export default function Hero() {
   return (
@@ -22,7 +23,9 @@ export default function Hero() {
             </p>
             <div className="flex flex-wrap gap-3.5">
               <a
-                href="#contacto"
+                href={whatsappUrl}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-lg bg-signal px-6 py-3.5 text-[14.5px] font-semibold text-ink transition-all hover:-translate-y-0.5 hover:shadow-[0_10px_24px_rgba(47,226,138,0.28)]"
               >
                 Agendar discovery call

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,3 +1,5 @@
+import { whatsappUrl } from "@/lib/site-config";
+
 export default function Nav() {
   return (
     <nav className="sticky top-0 z-50 border-b border-line bg-paper/85 backdrop-blur-md">
@@ -25,7 +27,9 @@ export default function Nav() {
             stack
           </a>
           <a
-            href="#contacto"
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
             className="rounded-md bg-ink px-4 py-2 font-mono text-[13px] font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-signal-deep"
           >
             Agendar call

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -11,4 +11,9 @@ export const siteConfig = {
   githubHandle: "valenciaHQ",
   location: "Buenos Aires, Argentina",
   locale: "es_AR",
+  whatsapp: "5491140317830",
 } as const;
+
+export const whatsappUrl = `https://wa.me/${siteConfig.whatsapp}?text=${encodeURIComponent(
+  "Hola! Quiero agendar una discovery call para hablar sobre mi proyecto.",
+)}`;


### PR DESCRIPTION
## Summary
- Agrega `CLAUDE.md` del proyecto (stack, npm, estructura, convenciones)
- Favicon dinámico (`app/icon.tsx`) y OG image dinámica (`app/opengraph-image.tsx`) vía `next/og`, con marca ValenciaHQ — antes el favicon era el default de Next y no había preview al compartir el link
- Agrega `.gitignore` (faltaba)
- "Agendar call" (Nav y Hero) ahora redirige a WhatsApp (`+54 9 11 4031-7830`) con mensaje inicial precargado, en vez de scrollear a `#contacto`
- En "Módulos de crecimiento orgánico" (`components/Addons.tsx`): solo "Auditoría y Remediación SEO" muestra precio y queda destacada; el resto pasa a un listado más chico, sin precio, de menor jerarquía visual

## Test plan
- [x] `npm run lint` y `npx tsc --noEmit` sin errores
- [x] `npm run build` genera `/icon` y `/opengraph-image` correctamente
- [x] Verificado en navegador: favicon, OG image, links de WhatsApp (href correcto) y layout de Addons