### PR TITLE
fix: SEO técnico — redirect apex, jerarquía H, H1 keyword, meta description

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -11,9 +11,10 @@ export default function Hero() {
               software a medida · seo técnico · buenos aires
             </span>
             <h1 className="mb-5 font-display text-[2.1rem] font-bold leading-[1.08] sm:text-[2.6rem] lg:text-[3.35rem]">
-              Ingeniería,
-              <br />
-              no artesanía <em className="text-signal not-italic">improvisada</em>.
+              Desarrollo Web y SEO Técnico en Buenos Aires
+              <span className="mt-3 block font-sans text-[1.05rem] font-normal leading-snug text-muted-onink sm:text-[1.15rem]">
+                Ingeniería, no artesanía <em className="text-signal not-italic">improvisada</em>.
+              </span>
             </h1>
             <p className="mb-8 max-w-[46ch] text-[17px] text-muted-onink">
               Tu primera web — o la que hace falta renovar — lista en días, no

--- a/components/Process.tsx
+++ b/components/Process.tsx
@@ -75,7 +75,7 @@ export default function Process() {
                 {phase.n}
               </span>
               <div>
-                <h4 className="mb-1.5 text-base font-bold">{phase.title}</h4>
+                <h3 className="mb-1.5 text-base font-bold">{phase.title}</h3>
                 <p className="text-[13.5px] text-muted">{phase.desc}</p>
               </div>
               <span className="hidden self-center rounded-md border border-signal-deep/25 bg-signal/10 px-2.5 py-2 text-center font-mono text-[11.5px] text-signal-deep sm:block">

--- a/components/SeoDiff.tsx
+++ b/components/SeoDiff.tsx
@@ -72,9 +72,9 @@ export default function SeoDiff() {
         <Reveal className="grid grid-cols-1 gap-7 sm:grid-cols-3">
           {FEATURES.map((f) => (
             <div key={f.title}>
-              <h4 className="mb-2 font-display text-[15px] font-bold text-white">
+              <h3 className="mb-2 font-display text-[15px] font-bold text-white">
                 {f.title}
-              </h4>
+              </h3>
               <p className="text-[13.5px] leading-relaxed text-muted-onink">
                 {f.desc}
               </p>

--- a/components/StackSection.tsx
+++ b/components/StackSection.tsx
@@ -26,9 +26,9 @@ export default function StackSection() {
         <Reveal className="grid grid-cols-1 gap-8 sm:grid-cols-3">
           {GROUPS.map((g) => (
             <div key={g.title}>
-              <h4 className="mb-3.5 font-mono text-xs uppercase tracking-wider text-muted">
+              <h3 className="mb-3.5 font-mono text-xs uppercase tracking-wider text-muted">
                 {g.title}
-              </h4>
+              </h3>
               <div className="flex flex-wrap gap-2">
                 {g.chips.map((chip) => (
                   <span

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -2,7 +2,7 @@ export const siteConfig = {
   name: "ValenciaHQ",
   title: "ValenciaHQ — Desarrollo Web, Sistemas a Medida y SEO Técnico",
   description:
-    "Ingeniería, no artesanía improvisada. Landing pages, sitios institucionales, productos a medida y SEO técnico para negocios de cualquier rubro. Buenos Aires, Argentina.",
+    "Desarrollo web y SEO técnico en Buenos Aires: landing pages, sitios institucionales y sistemas a medida para tu negocio, con primera entrega en 48–72hs.",
   // TODO: si el sitio termina viviendo en un subdominio en algún momento
   // (staging), actualizar esto y el metadataBase en app/layout.tsx.
   url: "https://www.valenciahq.com",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "valenciahq.com" }],
+        destination: "https://www.valenciahq.com/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Redirect 301 de `valenciahq.com` (apex) a `https://www.valenciahq.com` (HTTP y HTTPS), vía `redirects()` con matcher de `host` en `next.config.ts` — consolida señales SEO en el canonical existente.
- Corrige saltos de H2→H4 sin H3 intermedio en `SeoDiff`, `Process` y `StackSection` (ahora H2 > H3 en toda la página, sin saltos).
- Reescribe el H1 del Hero: lidera con la keyword de negocio ("Desarrollo Web y SEO Técnico en Buenos Aires"), el eslogan ("Ingeniería, no artesanía improvisada.") pasa a texto secundario dentro del mismo H1.
- Acorta la meta description de 168 a 152 caracteres, priorizando keyword + diferencial (SEO técnico, Buenos Aires, entrega 48–72hs).

## No incluido en este PR
- **Limpieza de scripts de dev (feedback widget / v0.png)**: no encontré ningún script, iframe ni asset de ese tipo en el código fuente (`app/`, `components/`, `public/` no existe). Si aparecen en el sitio en producción, probablemente los inyecta la plataforma de hosting/prototipado externamente — no hay nada que remover a nivel de código.
- **URLs individuales por servicio** (`/landing-web`, `/sitio-institucional`, `/desarrollo-a-medida`): el pedido original lo marca como "evaluar / opcional / mediano plazo". Recomendación: vale la pena a mediano plazo para long-tail, pero requiere copy único por página (evitar contenido duplicado con la home) — no es cambio de una sola sesión.
- **Imagen de contenido real con alt SEO**: el repo no tiene ningún asset de proyecto/equipo real (no hay carpeta `public/`). Falta que se provea un screenshot de un proyecto entregado o foto del equipo para agregarlo con alt descriptivo — no se puede generar/fabricar contenido que se presente como real.

## Test plan
- [x] `npm run build` pasa limpio (mismas 6 rutas estáticas que antes, sin nuevos assets pesados — sin riesgo esperado en LCP/CLS/TTFB)
- [x] `npm run lint` sin errores
- [x] Verificado visualmente en preview local: H1 renderiza correctamente, jerarquía de headings validada en las 3 secciones
- [ ] Verificar en Vercel que el dominio apex `valenciahq.com` esté asignado al proyecto para que el redirect por `host` header tenga efecto (si no está agregado en Project Settings → Domains, el redirect de `next.config.ts` no se ejecuta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)