### PR TITLE
feat: agregar tier Landing Express, sección Gestión y retainer portales inmobiliarios

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Nav from "@/components/Nav";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
+import GestionSection from "@/components/GestionSection";
 import SeoDiff from "@/components/SeoDiff";
 import Process from "@/components/Process";
 import StackSection from "@/components/StackSection";
@@ -15,6 +16,7 @@ export default function Home() {
       <Nav />
       <Hero />
       <Services />
+      <GestionSection />
       <SeoDiff />
       <Process />
       <StackSection />

--- a/components/Addons.tsx
+++ b/components/Addons.tsx
@@ -6,7 +6,7 @@ const FEATURED_ADDON = {
   price: "USD 150–250",
 };
 
-const OTHER_ADDONS = [
+const OTHER_ADDONS: { title: string; desc: string; price?: string }[] = [
   {
     title: "Crecimiento Orgánico Continuo",
     desc: "Retainer mensual, incluye hosting",
@@ -22,6 +22,11 @@ const OTHER_ADDONS = [
   {
     title: "Campañas Meta Ads",
     desc: "Segmentación local y reporte mensual",
+  },
+  {
+    title: "Integración y Sync con Portales Inmobiliarios",
+    desc: "Retainer mensual — ideal para clientes de la Plataforma de Gestión Inmobiliaria. Mantenimiento de feeds XML/API (Zonaprop, Argenprop, MercadoLibre Inmuebles), corrección ante cambios de esquema, monitoreo de sincronización.",
+    price: "USD 100–200/mes",
   },
 ];
 
@@ -64,6 +69,11 @@ export default function Addons() {
                 {a.title}
               </h4>
               <p className="text-[12px] text-muted">{a.desc}</p>
+              {a.price && (
+                <p className="mt-1.5 font-mono text-[11px] font-semibold text-signal-deep">
+                  {a.price}
+                </p>
+              )}
             </div>
           ))}
         </Reveal>

--- a/components/GestionSection.tsx
+++ b/components/GestionSection.tsx
@@ -1,0 +1,76 @@
+import Reveal from "./Reveal";
+
+type GestionTier = {
+  tag: string;
+  name: string;
+  price: string;
+  meta: string;
+  items: string[];
+};
+
+const GESTION_SERVICES: GestionTier[] = [
+  {
+    tag: "Sistemas Internos",
+    name: "Plataforma de Gestión Inmobiliaria (CRM + Listings)",
+    price: "USD 1,200–2,000",
+    meta: "MVP · inmobiliarias y agentes independientes",
+    items: [
+      "Panel de administración",
+      "Carga de propiedades con galería de imágenes y geolocalización",
+      "Gestión multi-agente con permisos diferenciados",
+      "Portal de búsqueda para clientes",
+      "Captura y seguimiento de leads",
+    ],
+  },
+];
+
+export default function GestionSection() {
+  return (
+    <section id="gestion" className="py-20">
+      <div className="mx-auto max-w-6xl px-7">
+        <Reveal className="mb-12 max-w-xl">
+          <span className="mb-3 block font-mono text-[12.5px] text-signal-deep">
+            gestión://
+          </span>
+          <h2 className="mb-3.5 text-[1.6rem] font-bold sm:text-[2.15rem]">
+            Sistemas a medida para operar tu negocio
+          </h2>
+          <p className="max-w-[56ch] text-[15.5px] text-muted">
+            Soluciones de gestión internas para negocios que necesitan
+            centralizar propiedades, agentes, leads o cualquier otro flujo de
+            operación en un solo panel.
+          </p>
+        </Reveal>
+
+        <div className="grid grid-cols-1">
+          {GESTION_SERVICES.map((s) => (
+            <Reveal key={s.name} className="max-w-md">
+              <div className="flex h-full flex-col rounded-[10px] border border-line bg-card p-7 transition-all hover:-translate-y-1 hover:border-signal-deep">
+                <span className="mb-3.5 font-mono text-[10.5px] uppercase tracking-wider text-muted">
+                  {s.tag}
+                </span>
+                <h3 className="mb-1.5 text-[19px] font-bold">{s.name}</h3>
+                <p className="mt-2.5 mb-1 font-mono text-[22px] font-semibold text-signal-deep">
+                  {s.price}
+                </p>
+                <p className="mb-4 font-mono text-[12.5px] text-muted">
+                  {s.meta}
+                </p>
+                <ul className="mb-1 flex flex-1 flex-col gap-2.5">
+                  {s.items.map((item) => (
+                    <li key={item} className="relative pl-4 text-sm text-text">
+                      <span className="absolute left-0 text-[13px] text-signal-deep">
+                        →
+                      </span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -12,6 +12,20 @@ type Service = {
 const SERVICES: Service[] = [
   {
     tag: "Web + SEO",
+    name: "Landing Express",
+    price: "USD 150–180",
+    meta: "Tiempo estimado: 24 a 48 horas",
+    items: [
+      "Ideal para negocios locales de baja rentabilidad",
+      "Una sola página",
+      "Template propio reutilizable",
+      "1 ronda de cambios",
+      "Despliegue de alta performance",
+      "No incluye Google Maps / Google Negocios (disponible como add-on)",
+    ],
+  },
+  {
+    tag: "Web + SEO",
     name: 'Landing "Impulso"',
     price: "USD 250–350",
     meta: "Tiempo estimado: 48 a 72 horas",
@@ -66,7 +80,7 @@ export default function Services() {
           </p>
         </Reveal>
 
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4">
           {SERVICES.map((s) => (
             <Reveal key={s.name}>
               <div


### PR DESCRIPTION
## Resumen

Actualización de precios/servicios según nueva estructura acordada:

- **Landing Express** (USD 150–180) — nuevo tier de entrada en "Soluciones Web + Fundamentos SEO", antes de "Impulso". Una página, template propio, 1 ronda de cambios, 24–48h. No incluye Google Maps/Negocios (disponible como add-on).
- **Sección nueva "Soluciones de Gestión (Sistemas Internos)"** — no existía en el repo (tampoco la "Plataforma de Turnos" referenciada en el brief original). Se crea con un solo tier por ahora: **Plataforma de Gestión Inmobiliaria (CRM + Listings) MVP** (USD 1,200–2,000). El tier de Turnos queda pendiente hasta tener contenido definido.
- **Retainer "Integración y Sync con Portales Inmobiliarios"** (USD 100–200/mes) — nuevo add-on en "Aceleradores de Crecimiento", pensado para clientes de la plataforma inmobiliaria.

## Archivos

- `components/Services.tsx` — tier nuevo + grid 3→4 columnas
- `components/Addons.tsx` — campo `price?` opcional en add-ons + retainer nuevo
- `components/GestionSection.tsx` — componente nuevo (mismo patrón visual que `Services.tsx`)
- `app/page.tsx` — wiring de la sección nueva entre `Services` y `SeoDiff`

Sin cambios de diseño/colores/layout general. Ningún tier existente tocado.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Verificado en preview local (`get_page_text`) que las 3 secciones renderizan el contenido nuevo sin errores de consola/servidor
- [ ] Revisar responsive del grid de 4 columnas en Services (mobile/tablet) en un navegador real

🤖 Generated with [Claude Code](https://claude.com/claude-code)